### PR TITLE
The one small change this developer made makes the address links look a bit more visible on Chrome

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -13,7 +13,6 @@ body{
 address a{
   font-style: normal;
   text-decoration: underline;
-  text-decoration-style: dashed;
 }
 
 .availabilityTable{


### PR DESCRIPTION
This is really just personal preference and you can decline this PR and tell me to go home (really, where else would I go?) and I would not be upset.

This just removes the "dashed" attribute from `address a` to improve visibility-mostly on Chrome.

# Chrome on Mac
Before:
![chrome-with-dashed](https://user-images.githubusercontent.com/454966/115159794-e0948100-a062-11eb-8f79-02d3b06857e1.png)

After:
![chrome-without-dashed](https://user-images.githubusercontent.com/454966/115159806-e8ecbc00-a062-11eb-9454-e4a743d83f9a.png)


Firefox and Safari on Mac both look ok ¯\\_(ツ)_/¯ 
FF:
![ff-with-dashed](https://user-images.githubusercontent.com/454966/115159813-f0ac6080-a062-11eb-8e42-9cd3e09ade0e.png)

(not including Safari screenshot since it looks similar to FF)